### PR TITLE
feat: add OPTIONS HTTP method support and apply minor code cleanup

### DIFF
--- a/src/smyth/__main__.py
+++ b/src/smyth/__main__.py
@@ -2,7 +2,7 @@ import logging
 import logging.config
 import os
 from enum import Enum
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 import uvicorn
@@ -36,10 +36,10 @@ def run(
         ),  # noqa: UP007
     ] = "smyth.server.app:create_app",
     factory: Annotated[bool, typer.Option(help="Use factory for app creation")] = True,
-    host: Annotated[Optional[str], typer.Option()] = config.host,  # noqa: UP007
-    port: Annotated[Optional[int], typer.Option()] = config.port,  # noqa: UP007
+    host: Annotated[str | None, typer.Option()] = config.host,  # noqa: UP007
+    port: Annotated[int | None, typer.Option()] = config.port,  # noqa: UP007
     log_level: Annotated[
-        Optional[LogLevel],  # noqa: UP007
+        LogLevel | None,  # noqa: UP007
         typer.Option(
             help=(
                 "Override the log level specified in the configuration, "

--- a/src/smyth/server/app.py
+++ b/src/smyth/server/app.py
@@ -48,7 +48,7 @@ class SmythStarlette(Starlette):
         self.add_route(
             "/{path:path}",
             lambda_invoker_endpoint,
-            methods=["GET", "POST", "PUT", "DELETE"],
+            methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
         )
 
 

--- a/src/smyth/utils.py
+++ b/src/smyth/utils.py
@@ -98,7 +98,7 @@ class LogRender:  # pragma: no cover
             process_name = record.processName
 
         return Text.from_markup(
-            f"{issuer}:" f"[bold]{process_name}[/]",
+            f"{issuer}:[bold]{process_name}[/]",
             style="log.process",
         )
 

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -72,7 +72,7 @@ def test_smyth_starlette(mocker):
         Route(
             "/{path:path}",
             lambda_invoker_endpoint,
-            methods=["DELETE", "GET", "HEAD", "POST", "PUT"],
+            methods=["DELETE", "GET", "HEAD", "POST", "PUT", "OPTIONS"],
         ),
     ]
 


### PR DESCRIPTION
## Summary

- Add `OPTIONS` to the list of allowed HTTP methods on the catch-all `/{path:path}` route, enabling CORS preflight and other OPTIONS-based requests.
- Modernize type annotations in `__main__.py` by replacing `Optional[X]` with `X | None` (PEP 604) and removing the unused import.
- Simplify an unnecessary f-string concatenation in `utils.py`.
- Update corresponding test assertions to include `OPTIONS` in the expected methods list.